### PR TITLE
Token Escaping

### DIFF
--- a/rosella_cli/src/main.rs
+++ b/rosella_cli/src/main.rs
@@ -53,42 +53,22 @@ fn main() {
     );*/
     let mut lexer = Lexer::new(
         r#"
-        let int x = 10;
-        let int y = 20;
-
-        let int result = x + y;
-        let str string = "this is a string";
-
-        let str appended_string = string + string2;
-
-        with windows {
-            if int(x > 0) {
-                let int x = 10;
-                let int y = 20;
-            }
-            else if int(x < 0) {
-                let int result = x + y;
-                let str string = "this is a string";
-            }
-            else {
-                let str string2 = "this is another string";
-                let str appended_string = string + string2;
-            }
+        fn add(x, y) {
+            let int result = x + y;
+            |> echo "$x + $y = $result";
         }
 
-        with linux {
-            while int(x < 100) {
-                let int x = x + 1;
-            }
+        add(1, 2);
+        add(3, 4);
+        add(5, 6);
 
-            fn add(x, y) {
-                let int result = x + y;
-            }
+        let int x = 0;
 
-            add(1, 2);
+        while int(x < 100) {
+            |> echo "Current value of x: $x"\; " and this is a test";
+            let int x = x + 1;
         }
 
-        |> echo "Hello World";
         "#
     );
 

--- a/rosella_lib/src/compiler.rs
+++ b/rosella_lib/src/compiler.rs
@@ -62,7 +62,6 @@ impl Compiler {
                 Ok(self.compile_function_call(name, args)?)
             }
             Stmt::RawInstruction(instructions) => Ok(self.compile_raw_instruction(instructions)?),
-            //_ => unimplemented!("Statement type is not implemented for compilation: {:?}", statement),
         }
     }
 
@@ -255,7 +254,7 @@ impl Compiler {
                     (Shell::Bash, "int") => {
                         match operator {
                             BinaryOp::Add | BinaryOp::Subtract | BinaryOp::Multiply | BinaryOp::Divide => {
-                                return Ok(format!("(({} {} {}))", left_str, operator_str, right_str));
+                                return Ok(format!("$(({} {} {}))", left_str, operator_str, right_str));
                             },
                             _ => return Ok(format!("{} {} {}", left_str, operator_str, right_str))
                         }

--- a/rosella_lib/src/lexer.rs
+++ b/rosella_lib/src/lexer.rs
@@ -40,6 +40,7 @@ pub enum Token {
     LBraceSquare,           // [
     RBraceSquare,           // ]
     
+    Escape,                 // \ (used for escaping characters)
     Comma,                  // ,
     Semicolon,              // ;
 
@@ -146,6 +147,10 @@ impl Lexer {
         self.advance();
 
         match current_char {
+            Some('\\') => {
+                self.advance();
+                Ok(Token::Escape)
+            },
             Some('=') => {
                 if self.current_character == Some('=') {
                     self.advance();

--- a/rosella_lib/src/parser.rs
+++ b/rosella_lib/src/parser.rs
@@ -101,6 +101,10 @@ impl Parser {
         if self.position < self.tokens.len(){
            self.position += 1;
         }
+        
+        if self.current_token() == &Token::Escape {
+            self.position += 1;
+        }
     }
 
     fn expect_token(&mut self, expected: &Token) -> Result<(), RosellaError> {


### PR DESCRIPTION
Tokens can be skipped by the parser by prefixing them with '\'. Most useful to prevent RawInstruction from exiting early.

Numerical calculations are more robust